### PR TITLE
Fix oow_db_name helper

### DIFF
--- a/bin/utils.sh
+++ b/bin/utils.sh
@@ -5,13 +5,13 @@ oow_addons_path() {
 oow_docker_name() { docker ps | awk '/oow-commown/ {print $NF}'; }
 
 oow_db_name() {
-    if grep '^12\.' /etc/debian_version > /dev/null ; then
-	docker inspect $(oow_docker_name) | awk -F'[="]' '/--database/ {print $3; exit}'
+    if docker inspect $(oow_docker_name) | grep -- "--database=" > /dev/null ; then
+        docker inspect $(oow_docker_name) | awk -F'[="]' '/--database/ {print $3; exit}'
     else
-	docker inspect $(oow_docker_name) \
-	    | grep -A1 -- '--database' \
-	    | tail -1 \
-	    | tr -d '", '
+        docker inspect $(oow_docker_name) \
+	        | grep -A1 -- '--database' \
+	        | tail -1 \
+	        | tr -d '", '
     fi
 }
 


### PR DESCRIPTION
# Context : 

`docker inspect` has a different way to display information about the name of the used database depending on the version or configuration of docker.
It was assumed that this difference was due to the Debian version - however, two docker instances on Debian 12 seem to show differing inspects, resulting in an incorrect db_name

# Fix

Rather than checking if Debian 12 is the OS of the system, we check if the `docker inspect` command shows the name of the database on the same line (with the presence of the string ``--database=``) or not, and we fetch the info accordingly